### PR TITLE
Handling congestion control

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,10 +15,15 @@ class RoundRobinStream extends Writable {
 
   _write(chunk, enc, next){
     let stream = this.streams.next();
+    let nextStream = this.streams.peek();
 
     stream.write(chunk);
 
-    next();
+    if (nextStream._writableState.needDrain) {
+      nextStream.once('drain', next);
+    } else {
+      next();
+    }
   }
 
   createReadStream() {

--- a/iterator.js
+++ b/iterator.js
@@ -24,18 +24,20 @@ module.exports = class Iterator {
   }
 
   next() {
-    this._incrementCurrent();
+    this.current = this._calculateNextCurrent();
 
     return this.items[this.current];
   }
 
+  peek() {
+    return this.items[this._calculateNextCurrent()];
+  }
 
-  _incrementCurrent() {
+  _calculateNextCurrent() {
     if (this.items.length === 0) {
-      this.current = -1;
-      return;
+      return -1;
     }
 
-    this.current = (this.current + 1) % this.items.length;
+    return (this.current + 1) % this.items.length;
   }
 }

--- a/test/index_test.js
+++ b/test/index_test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Readable         = require('stream').Readable;
+const Writable         = require('stream').Writable;
 const test             = require('tape');
 const RoundRobinStream = require('../');
 
@@ -91,4 +93,38 @@ test('handles removals correctly in all cases', (t) => {
 
   rrstream.write('hello again');
   rrstream.write('goodbye again');
+});
+
+test('stops the producer if the next consumer can\'t keep up', (t) => {
+  t.plan(1);
+
+  let rrstream = new RoundRobinStream({ objectMode: true, highWaterMark: 1 });
+  let stream1  = rrstream.createReadStream();
+  let stream2  = rrstream.createReadStream();
+
+  let counterValue = 100;
+  let counterReadableStream = new Readable({
+    read: function (size) {
+      if (counterValue-- > 0) {
+        this.push({ counter: counterValue });
+      } else {
+        this.push(null);
+      }
+    },
+    objectMode: true
+  });
+
+  let printWritableStream = new Writable({
+    write(chunk, encoding, callback) {
+      // It's not consuming data
+    },
+    objectMode: true
+  });
+
+  stream1.pipe(printWritableStream);
+  stream2.pipe(printWritableStream);
+
+  counterReadableStream.pipe(rrstream);
+
+  setTimeout(() => t.ok(counterValue > 0), 50);
 });


### PR DESCRIPTION
Using the stream#write return value and the 'drain' event, it's now able
to notify the producer if the next consumer is runnig slower and the
buffers are filled up, in that situation the producer must stop writing
data.